### PR TITLE
Fix Babel helper binding renaming

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,6 @@ export default function babel ( options ) {
 
 			return buildExternalHelpers( helpers, 'var' )
 				.replace( /var babelHelpers = {};\n/, '' )
-				.replace( /babelHelpers\.(.+) = function(?: \w+)?/g, 'function babelHelpers_$1' )
 				.replace( /babelHelpers\.(.+) = /g, 'var babelHelpers_$1 = ' )
 				.replace( 'babelHelpers;', '' ) // not sure where this comes from...
 				.trim() + '\n';

--- a/test/test.js
+++ b/test/test.js
@@ -54,7 +54,7 @@ describe( 'rollup-plugin-babel', function () {
 			var generated = bundle.generate();
 			var code = generated.code;
 
-			assert.ok( code.indexOf( 'function babelHelpers_classCallCheck' ) !== -1, generated.code );
+			assert.ok( code.indexOf( 'babelHelpers_classCallCheck =' ) !== -1, generated.code );
 			assert.ok( code.indexOf( 'var _createClass =' ) === -1, generated.code );
 		});
 	});


### PR DESCRIPTION
The renaming from `babelHelpers.foo =` to a function declaration `function babelHelpers_foo()` was incorrect as the helpers are defined as expressions.

This puts back the helper functions being defined as function expressions but keeps the better-minifiable `babelHelpers_` bindings.

See: https://github.com/rollup/rollup-plugin-babel/pull/19#issuecomment-169540385