### PR TITLE
Remove Babel helper binding renaming

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ export default function babel ( options ) {
 			}
 
 			return {
-				code: transformed.code.replace( /babelHelpers\./g, 'babelHelpers_' ),
+				code: transformed.code,
 				map: transformed.map
 			};
 		},
@@ -104,11 +104,7 @@ export default function babel ( options ) {
 			const helpers = Object.keys( bundledHelpers );
 			if ( !helpers.length ) return '';
 
-			return buildExternalHelpers( helpers, 'var' )
-				.replace( /var babelHelpers = {};\n/, '' )
-				.replace( /babelHelpers\.(.+) = /g, 'var babelHelpers_$1 = ' )
-				.replace( 'babelHelpers;', '' ) // not sure where this comes from...
-				.trim() + '\n';
+			return buildExternalHelpers( helpers, 'var' ).trim() + '\n';
 		}
 	};
 }

--- a/test/test.js
+++ b/test/test.js
@@ -54,7 +54,7 @@ describe( 'rollup-plugin-babel', function () {
 			var generated = bundle.generate();
 			var code = generated.code;
 
-			assert.ok( code.indexOf( 'babelHelpers_classCallCheck =' ) !== -1, generated.code );
+			assert.ok( code.indexOf( 'babelHelpers.classCallCheck =' ) !== -1, generated.code );
 			assert.ok( code.indexOf( 'var _createClass =' ) === -1, generated.code );
 		});
 	});


### PR DESCRIPTION
The attempt to fix the Babel helper binding renaming in #31 didn't work for all cases. The `transform-object-rest-spread` uses:

```js
babelHelpers['extends']
```

It seems safer to just remove this optimization, and let the helpers stay named `babelHelpers.`.