### PR TITLE
Adding support for referencing external, global helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ rollup({
 }).then(...)
 ```
 
-All options are as per the [Babel documentation](https://babeljs.io/), except `options.include` and `options.exclude` (each a minimatch pattern, or array of minimatch patterns), which determine which files are transpiled by Babel (by default, all files are transpiled).
+All options are as per the [Babel documentation](https://babeljs.io/), except `options.externalHelpers` (a boolean value indicating whether to bundle in the babel helpers), `options.include` and `options.exclude` (each a minimatch pattern, or array of minimatch patterns), which determine which files are transpiled by Babel (by default, all files are transpiled).
 
 Babel will respect `.babelrc` files – this is generally the best place to put your configuration.
 
@@ -90,6 +90,19 @@ rollup.rollup({
 }).then(...)
 ```
 
+Finally, if you do not wish the babel helpers to be included in your bundle at all (but instead reference the global `babelHelpers` object), you may set the `externalHelpers` option to `true`:
+
+```js
+rollup.rollup({
+  ...,
+  plugins: [
+    babel({
+      plugins: ['external-helpers-2'],
+      externalHelpers: true
+    })
+  ]
+}).then(...)
+```
 
 ## License
 

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,10 @@ export default function babel ( options ) {
 	const runtimeHelpers = options.runtimeHelpers;
 	delete options.runtimeHelpers;
 
+	var externalHelpers;
+	if ( options.externalHelpers ) externalHelpers = true;
+	delete options.externalHelpers;
+
 	return {
 		transform ( code, id ) {
 			if ( !filter( id ) ) return null;
@@ -101,6 +105,7 @@ export default function babel ( options ) {
 			};
 		},
 		intro () {
+			if ( externalHelpers ) return '';
 			const helpers = Object.keys( bundledHelpers );
 			if ( !helpers.length ) return '';
 

--- a/test/test.js
+++ b/test/test.js
@@ -71,6 +71,19 @@ describe( 'rollup-plugin-babel', function () {
 		});
 	});
 
+	it( 'does not add helpers when externalHelpers option is truthy', function () {
+		return rollup.rollup({
+			entry: 'samples/class/main.js',
+			plugins: [ babelPlugin({externalHelpers: true}) ]
+		}).then( function ( bundle ) {
+			var generated = bundle.generate();
+			var code = generated.code;
+
+			assert.ok( code.indexOf( 'babelHelpers =' ) === -1, generated.code );
+			assert.ok( code.indexOf( 'babelHelpers.classCallCheck =' ) === -1, generated.code );
+		});
+	});
+
 	it( 'does not babelify excluded code', function () {
 		return rollup.rollup({
 			entry: 'samples/exclusions/main.js',


### PR DESCRIPTION
This adds a backwards-compatible option for indicating that you want to call babel helpers on the global `babelHelpers` object, instead of inlining the functions for this bundle.

I hesitated to add an option to the plugin that is not part of the normal babel options, but saw no other way to add in this feature without breaking backwards compatibility of code already using rollup-plugin-babel. The reason why it could not be solved with any combination of plugins is because [rollup-plugin-babel assumes that babelHelpers need to be bundled](https://github.com/rollup/rollup-plugin-babel/blob/dec1704c41637bb05e65ae04923358366008f3f3/src/index.js#L28) even when you use the external-helpers or external-helpers-2 plugins. Also see [here](https://github.com/rollup/rollup-plugin-babel/blob/dec1704c41637bb05e65ae04923358366008f3f3/src/index.js#L81-L84) and [here](https://github.com/rollup/rollup-plugin-babel/blob/dec1704c41637bb05e65ae04923358366008f3f3/src/index.js#L104) for the relevant code I'm referring to.

If there is some combination of `external-helpers` plugins that works without this pull request, then I'm all ears and will gladly switch to that and close this :)