### PR TITLE
Extract mocha options into their own file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "test": "mocha --compilers js:buble/register",
+    "test": "mocha",
     "prepublish": "npm run test",
     "pretest": "npm run build",
     "build": "rollup -c -f cjs -o dist/rollup-plugin-babel.cjs.js && rollup -c -f es6 -o dist/rollup-plugin-babel.es6.js",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--compilers js:buble/register


### PR DESCRIPTION
This allows IDEs/other runners to have less duplicate configuration.