### PR TITLE
`Generates sourcemap by default` spec failing

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -106,17 +106,19 @@ describe( 'rollup-plugin-babel', function () {
 			entry: 'samples/class/main.js',
 			plugins: [ babelPlugin() ]
 		}).then( function ( bundle ) {
+			var target = 'log';
 			var generated = bundle.generate({ sourceMap: true });
 			var smc = new SourceMapConsumer( generated.map );
 
-			var loc = getLocation( generated.code, generated.code.indexOf( 'log' ) );
+			var loc = getLocation( generated.code, generated.code.indexOf( target ) );
+
 			var original = smc.originalPositionFor( loc );
 
 			assert.deepEqual( original, {
 				source: path.resolve( 'samples/class/main.js' ).split( path.sep ).join( '/' ),
 				line: 3,
 				column: 10,
-				name: null
+				name: target
 			});
 		});
 	});


### PR DESCRIPTION
   :wrench: **change test to reconcile dependency bump of `source-map@0.5.6`**

   References #81

  `source-map@0.5.6` Regression failure reference
  https://github.com/mozilla/source-map/pull/236

  In particular the following diff:
  https://github.com/mozilla/source-map/pull/236/files#diff-72d90d7b160cfdc50eee99b2a33c871cL320

  https://bugzilla.mozilla.org/show_bug.cgi?id=889492
