### PR TITLE
Remove recommendation to change Babel preset from lib

### DIFF
--- a/src/preflightCheck.js
+++ b/src/preflightCheck.js
@@ -17,7 +17,7 @@ export default function preflightCheck ( options, dir ) {
 
 		const check = transform( 'export default class Foo {}', options ).code;
 
-		if ( !~check.indexOf( 'export default' ) && !~check.indexOf( 'export { Foo as default }' ) ) throw new Error( 'It looks like your Babel configuration specifies a module transformer. Please disable it. If you\'re using the "es2015" preset, consider using "es2015-rollup" instead. See https://github.com/rollup/rollup-plugin-babel#configuring-babel for more information' );
+		if ( !~check.indexOf( 'export default' ) && !~check.indexOf( 'export { Foo as default }' ) ) throw new Error( 'It looks like your Babel configuration specifies a module transformer. Please disable it. See https://github.com/rollup/rollup-plugin-babel#configuring-babel for more information' );
 
 		if ( ~check.indexOf( 'import _classCallCheck from "babel-runtime' ) ) helpers = RUNTIME;
 		else if ( ~check.indexOf( 'function _classCallCheck' ) ) helpers = INLINE;

--- a/test/test.js
+++ b/test/test.js
@@ -137,7 +137,7 @@ describe( 'rollup-plugin-babel', function () {
 				assert.ok( false, 'promise should not fulfil' );
 			})
 			.catch( function ( err ) {
-				assert.ok( /es2015-rollup/.test( err.message ), 'Expected an error about external helpers or module transform, got "' + err.message + '"' );
+				assert.ok( /configuring-babel/.test( err.message ), 'Expected an error about external helpers or module transform, got "' + err.message + '"' );
 			});
 	});
 
@@ -146,7 +146,7 @@ describe( 'rollup-plugin-babel', function () {
 			entry: 'samples/runtime-helpers/main.js',
 			plugins: [ babelPlugin({ runtimeHelpers: true }) ],
 			onwarn: function ( msg ) {
-				assert.equal( msg, `Treating 'babel-runtime/helpers/classCallCheck' as external dependency` );
+				assert.equal( msg, 'Treating \'babel-runtime/helpers/classCallCheck\' as external dependency' );
 			}
 		}).then( function ( bundle ) {
 			var cjs = bundle.generate({ format: 'cjs' }).code;
@@ -159,7 +159,7 @@ describe( 'rollup-plugin-babel', function () {
 			entry: 'samples/named-function-helper/main.js',
 			plugins: [ babelPlugin() ],
 			onwarn: function ( msg ) {
-				assert.equal( msg, `Treating 'babel-runtime/helpers/classCallCheck' as external dependency` );
+				assert.equal( msg, 'Treating \'babel-runtime/helpers/classCallCheck\' as external dependency' );
 			}
 		}).then( function ( bundle ) {
 			var cjs = bundle.generate({ format: 'cjs' }).code;
@@ -184,7 +184,7 @@ describe( 'rollup-plugin-babel', function () {
 		}).then( () => {
 			console.warn = consoleWarn;
 			assert.deepEqual( messages, [
-				`The 'classCallCheck' Babel helper is used more than once in your code. It's strongly recommended that you use the "external-helpers" plugin or the "es2015-rollup" preset. See https://github.com/rollup/rollup-plugin-babel#configuring-babel for more information`
+				'The \'classCallCheck\' Babel helper is used more than once in your code. It\'s strongly recommended that you use the "external-helpers" plugin or the "es2015-rollup" preset. See https://github.com/rollup/rollup-plugin-babel#configuring-babel for more information'
 			]);
 		});
 	});


### PR DESCRIPTION
This just updates the recommendation to match what is already specified in `README.md`.

Note: I have my editor configured to run `ESLint` with `--fix` using a project's `.eslintrc`, so a few changes were made in the file. Let me know if you'd prefer the way it was before and I'll just commit the hunk with the change relating to the PR.

CI will likely fail due to https://github.com/rollup/rollup-plugin-babel/issues/81
