### PR TITLE
Updated external-helpers package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ rollup.rollup({
   ...,
   plugins: [
     babel({
-      plugins: ['external-helpers-2'],
+      plugins: ['external-helpers'],
       externalHelpers: true
     })
   ]


### PR DESCRIPTION
`babel-plugin-external-helpers-2` has been renamed to `babel-plugin-external-helpers`.

See: https://github.com/babel/babel/pull/3205
