### PR TITLE
clarify README.md showing an example excluding helpers with a variable set to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ rollup.rollup({
 }).then(...)
 ```
 
-Finally, if you do not wish the babel helpers to be included in your bundle at all (but instead reference the global `babelHelpers` object), you may set the `externalHelpers` option to `true`:
+By default `externalHelpers` option is set to `false` so babel helpers will be included in your bundle.
+
+If you do not wish the babel helpers to be included in your bundle at all (but instead reference the global `babelHelpers` object), you may set the `externalHelpers` option to `true`:
 
 ```js
 rollup.rollup({


### PR DESCRIPTION
I have just spent hours configuring my rollup because of this.

I found the example not to be the standard behavor, also the key used `externalHelpers` bring confusion when set to true. I just needed to have the plugin to make it work.

Seems obvious when you see your mistake, but I think this will clarify, I hesitated showing the wanted example instead of that one.


