### PR TITLE
Use "module" in addition to "jsnext:main"

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0-alpha.12",
   "description": "Seamless integration between Rollup and Babel.",
   "main": "dist/rollup-plugin-babel.cjs.js",
+  "module": "dist/rollup-plugin-babel.es.js",
   "jsnext:main": "dist/rollup-plugin-babel.es.js",
   "files": [
     "src",


### PR DESCRIPTION
See https://github.com/rollup/rollup-plugin-alias/pull/28 for detailed description. Basically, I have an error, it gets fixed if I change the default settings of the `rollup-plugin-node-resolve plugin` to use "jsnext". This change would make bundling `rollup-plugin-babel` with `rollup-plugin-node-resolve` work by default.