### PR TITLE
Fix regression with Babel 6

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,22 @@ build: off
 
 test_script:
   - node --version && npm --version
+  - echo -- BABEL 7 --
+  - npm test
+  - echo Replacing Babel 7 with Babel 6
+  - npm remove
+      babel-core
+      babel-plugin-external-helpers
+      babel-plugin-transform-decorators
+      babel-plugin-transform-runtime
+      babel-preset-es2015
+  - npm install
+      babel-core@6
+      babel-plugin-external-helpers@6
+      babel-plugin-transform-decorators@6
+      babel-plugin-transform-runtime@6
+      babel-preset-es2015@6
+  - echo -- BABEL 6 --
   - npm test
 
 matrix:

--- a/src/helperPlugin.js
+++ b/src/helperPlugin.js
@@ -1,8 +1,25 @@
-export default function importHelperPlugin () {
+export default function importHelperPlugin ({ types: t }) {
+	/**
+	 * This function is needed because of a bug in Babel 6.x, which prevents the
+	 * declaration of an ExportDefaultDeclaration to be replaced with an
+	 * expression.
+	 * That bug has been fixed in Babel 7.
+	 */
+	function replaceWith (path, replacement) {
+		if (
+			path.parentPath.isExportDefaultDeclaration() &&
+			t.isExpression(replacement)
+		) {
+			path.parentPath.replaceWith(t.exportDefaultDeclaration(replacement));
+		} else {
+			path.replaceWith(replacement);
+		}
+	}
+
 	return {
 		visitor: {
 			ClassDeclaration (path, state) {
-				path.replaceWith(state.file.addHelper('classCallCheck'));
+				replaceWith(path, state.file.addHelper('classCallCheck'));
 			}
 		}
 	};

--- a/test/helperPlugin.js
+++ b/test/helperPlugin.js
@@ -1,8 +1,25 @@
-module.exports = function importHelperPlugin () {
+module.exports = function importHelperPlugin({ types: t }) {
+  /**
+   * This function is needed because of a bug in Babel 6.x, which prevents the
+   * declaration of an ExportDefaultDeclaration to be replaced with an
+   * expression.
+   * That bug has been fixed in Babel 7.
+   */
+  function replaceWith(path, replacement) {
+    if (
+      path.parentPath.isExportDefaultDeclaration() &&
+      t.isExpression(replacement)
+    ) {
+      path.parentPath.replaceWith(t.exportDefaultDeclaration(replacement));
+    } else {
+      path.replaceWith(replacement);
+    }
+  }
+
   return {
     visitor: {
-      ClassDeclaration (path, state) {
-        path.replaceWith(state.file.addHelper('classCallCheck'));
+      ClassDeclaration(path, state) {
+        replaceWith(path, state.file.addHelper("classCallCheck"));
       }
     }
   };


### PR DESCRIPTION
Since in Babel 6 it is not supported to replace the argument of a default export declaration with an expression, use a custom "replaceWith" function which handles also that case.

Fixes #155, fixes #156.