### PR TITLE
Remove unused namespace declaration & expression

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ export default function babel ( options ) {
 
 				const helpers = buildExternalHelpers( externalHelpersWhitelist, 'var' )
 					.replace(/^var babelHelpers = \{\};\n/gm, '')
-					.replace(/^babelHelpers;\n/gm, '')
+					.replace(/\nbabelHelpers;$/gm, '')
 					.replace( pattern, 'var _$1' )
 					.replace( /^babelHelpers\./gm, 'export var ' ) +
 					`\n\nexport { ${keywordHelpers.map( word => `_${word} as ${word}`).join( ', ')} }`;

--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,8 @@ export default function babel ( options ) {
 				const pattern = new RegExp( `babelHelpers\\.(${keywordHelpers.join('|')})`, 'g' );
 
 				const helpers = buildExternalHelpers( externalHelpersWhitelist, 'var' )
+					.replace(/^var babelHelpers = \{\};\n/gm, '')
+					.replace(/^babelHelpers;\n/gm, '')
 					.replace( pattern, 'var _$1' )
 					.replace( /^babelHelpers\./gm, 'export var ' ) +
 					`\n\nexport { ${keywordHelpers.map( word => `_${word} as ${word}`).join( ', ')} }`;


### PR DESCRIPTION
Its minor and optimized away in minification, but in a react-native environment these left-over bits cause problems. 
The babelHelpers assignment somehow replaces the global one...which i think is a bug on their part, but I still think this is good to do.