### PR TITLE
Recommend @beta dist tag instead of @next

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm install --save-dev rollup-plugin-babel@latest
 > babel 7.x - beta
 
 ```bash
-npm install --save-dev rollup-plugin-babel@next
+npm install --save-dev rollup-plugin-babel@beta
 ```
 
 ## Usage


### PR DESCRIPTION
The latest beta seems to have been tagged as `@beta`:

```
$ npm view rollup-plugin-babel dist-tags
{ latest: '3.0.3', next: '4.0.0-beta.0', beta: '4.0.0-beta.2' }
```