### PR TITLE
Restore NUL convention for helper name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-babel",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,4 +2,6 @@ export const INLINE = {};
 export const RUNTIME = {};
 export const EXTERNAL = {};
 
-export const HELPERS = 'rollupPluginBabelHelpers';
+// NOTE: DO NOT REMOVE the null character `\0` as it may be used by other plugins
+// e.g. https://github.com/rollup/rollup-plugin-node-resolve/blob/313a3e32f432f9eb18cc4c231cc7aac6df317a51/src/index.js#L74
+export const HELPERS = '\0rollupPluginBabelHelpers';

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@ var SourceMapConsumer = require( 'source-map' ).SourceMapConsumer;
 var babelPlugin = require( '..' );
 
 // from ./src/constants
-var HELPERS = 'rollupPluginBabelHelpers';
+var HELPERS = '\0rollupPluginBabelHelpers';
 
 require( 'source-map-support' ).install();
 


### PR DESCRIPTION
The null character `\0` seems to have first been introduced by d169da1.

Fixes #197