### PR TITLE
Fix npm beta label in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm install --save-dev rollup-plugin-babel@latest
 > babel 7.x - beta
 
 ```bash
-npm install --save-dev rollup-plugin-babel@next
+npm install --save-dev rollup-plugin-babel@beta
 ```
 
 ## Usage


### PR DESCRIPTION
Previously, the instructions for usage with Babel 7 was to install the plugin with the label "next" which doesn't exist. The correct label is "beta".