### PR TITLE
Removing externalHelpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,7 @@ rollup.rollup({
   ...,
   plugins: [
     babel({
-      plugins: ['external-helpers'],
-      externalHelpers: true
+      plugins: ['external-helpers']
     })
   ]
 }).then(...)


### PR DESCRIPTION
`externalHelpers` was removed in babel 5