### PR TITLE
Add support for esm and builtin runtime helpers

### DIFF
--- a/src/preflightCheck.js
+++ b/src/preflightCheck.js
@@ -54,8 +54,7 @@ export default function createPreflightCheck () {
 				ctx.error( MODULE_ERROR );
 			}
 
-      console.log(check)
-      if ( check.match( /\/helpers\/(builtin\/)?(es6\/)?inherits/ ) ) helpers = RUNTIME;
+			if ( check.match( /\/helpers\/(builtin\/)?(es6\/)?inherits/ ) ) helpers = RUNTIME;
 			else if ( ~check.indexOf( 'function _inherits' ) ) helpers = INLINE;
 			else if ( ~check.indexOf( 'babelHelpers' ) ) helpers = EXTERNAL;
 			else {

--- a/src/preflightCheck.js
+++ b/src/preflightCheck.js
@@ -54,7 +54,8 @@ export default function createPreflightCheck () {
 				ctx.error( MODULE_ERROR );
 			}
 
-			if ( ~check.indexOf( '/helpers/inherits' ) ) helpers = RUNTIME;
+      console.log(check)
+      if ( check.match( /\/helpers\/(builtin\/)?(es6\/)?inherits/ ) ) helpers = RUNTIME;
 			else if ( ~check.indexOf( 'function _inherits' ) ) helpers = INLINE;
 			else if ( ~check.indexOf( 'babelHelpers' ) ) helpers = EXTERNAL;
 			else {

--- a/test/samples/runtime-helpers-builtins/.babelrc
+++ b/test/samples/runtime-helpers-builtins/.babelrc
@@ -1,0 +1,6 @@
+{
+  "presets": [ ["@babel/env", { "modules": false } ] ],
+  "plugins": [
+    [ "@babel/transform-runtime", { "useBuiltIns": true } ]
+  ]
+}

--- a/test/samples/runtime-helpers-builtins/main.js
+++ b/test/samples/runtime-helpers-builtins/main.js
@@ -1,0 +1,3 @@
+export default class Foo {
+	
+}

--- a/test/samples/runtime-helpers-esm/.babelrc
+++ b/test/samples/runtime-helpers-esm/.babelrc
@@ -1,0 +1,6 @@
+{
+  "presets": [ ["@babel/env", { "modules": false } ] ],
+  "plugins": [
+    [ "@babel/transform-runtime", { "useESModules": true, "useBuiltIns": true } ]
+  ]
+}

--- a/test/samples/runtime-helpers-esm/main.js
+++ b/test/samples/runtime-helpers-esm/main.js
@@ -1,0 +1,3 @@
+export default class Foo {
+	
+}

--- a/test/test.js
+++ b/test/test.js
@@ -138,6 +138,28 @@ describe( 'rollup-plugin-babel', function () {
 		});
 	});
 
+	it( 'allows transform-runtime to inject builtin version of helpers', () => {
+		return bundle(
+			'samples/runtime-helpers-esm/main.js',
+			{ runtimeHelpers: true },
+			{},
+			{}
+		).then(({ code }) => {
+			assert.ok( !~code.indexOf( HELPERS ) );
+		});
+	});
+
+	it( 'allows transform-runtime to inject esm version of helpers', () => {
+		return bundle(
+			'samples/runtime-helpers-esm/main.js',
+			{ runtimeHelpers: true },
+			{},
+			{}
+		).then(({ code }) => {
+			assert.ok( !~code.indexOf( HELPERS ) );
+		});
+	});
+
 	it( 'allows transform-runtime to be used instead of bundled helpers, but throws when CommonJS is used', () => {
 		return bundle(
 			'samples/runtime-helpers-commonjs/main.js',


### PR DESCRIPTION
This diff adds support for `useESModules` and `useBuiltIns` options
in transform-runtime plugin which injects paths with `es6` and `builtin`
suffixes.