### PR TITLE
Fix `rollup` peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "peerDependencies": {
     "@babel/core": "7 || ^7.0.0-rc.2",
-    "rollup": "^0.60.0"
+    "rollup": ">=0.60.0 <1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",


### PR DESCRIPTION
Semver range `^0.60.0` doesn't include `0.65.0`, etc., as if major version is 0, minor version updates indicate breaking changes. `>1` is added for future-proof.