### PR TITLE
Remove babel 6 test from AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,6 @@ build: off
 
 test_script:
   - node --version && npm --version
-  - echo -- BABEL 7 --
   - npm test
 
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,21 +24,6 @@ test_script:
   - node --version && npm --version
   - echo -- BABEL 7 --
   - npm test
-  - echo Replacing Babel 7 with Babel 6
-  - npm remove
-      babel-core
-      babel-plugin-external-helpers
-      babel-plugin-transform-decorators
-      babel-plugin-transform-runtime
-      babel-preset-es2015
-  - npm install
-      babel-core@6
-      babel-plugin-external-helpers@6
-      babel-plugin-transform-decorators@6
-      babel-plugin-transform-runtime@6
-      babel-preset-es2015@6
-  - echo -- BABEL 6 --
-  - npm test
 
 matrix:
   fast_finish: false


### PR DESCRIPTION
Removes babel 6 test from AppVeyor. Will only run the test against babel 7.