### PR TITLE
Fix indentation in examples of configuration in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ However, setting `modules: false` in your `.babelrc` may conflict if you are usi
 
 ```js
 plugins: [
-	babel({
-		babelrc: false,
-		presets: [['env', { modules: false }]],
-	}),
+  babel({
+    babelrc: false,
+    presets: [['env', { modules: false }]],
+  }),
 ];
 ```
 


### PR DESCRIPTION
All examples of configuration in readme use spaces for indentations.
I updated the last one that was using tabs instead of spaces. Now every example should look consistent with others.