### PR TITLE
Add js extension to helper file

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -4,4 +4,4 @@ export const EXTERNAL = {};
 
 // NOTE: DO NOT REMOVE the null character `\0` as it may be used by other plugins
 // e.g. https://github.com/rollup/rollup-plugin-node-resolve/blob/313a3e32f432f9eb18cc4c231cc7aac6df317a51/src/index.js#L74
-export const HELPERS = '\0rollupPluginBabelHelpers';
+export const HELPERS = '\0rollupPluginBabelHelpers.js';

--- a/test/test.js
+++ b/test/test.js
@@ -6,7 +6,7 @@ var jsonPlugin = require('rollup-plugin-json');
 var babelPlugin = require('..');
 
 // from ./src/constants
-var HELPERS = '\0rollupPluginBabelHelpers';
+var HELPERS = '\0rollupPluginBabelHelpers.js';
 
 require('source-map-support').install();
 


### PR DESCRIPTION
When setting `preserveModules: true` in the Rollup config Rollup outputs the helpers in a file in `{config.dir}/_virtual/_rollupPluginBabelHelpers` (without an extension).

This pull request will add the `.js` extension so it's an actual javascript file in `{config.dir}/_virtual/_rollupPluginBabelHelpers.js` (with an extension).

This implementation will not break anything as far as I know.