### PR TITLE
Add supportsTopLevelAwait caller flag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ const unpackOptions = ({
 		name: 'rollup-plugin-babel',
 		supportsStaticESM: true,
 		supportsDynamicImport: true,
+		supportsTopLevelAwait: true,
 		...rest.caller,
 	},
 });


### PR DESCRIPTION
This flag, which will be introduced in v7.7.0, will enable support for _parsing_ top-level await (https://github.com/babel/babel/pull/10573).

I think that it's safe to enable by default (and I coudn't find a way to read the rollup top level options from the transform hook :sweat_smile:): if a user doesn't have the `experimentalTopLevelAwait` option enabled, the only difference is that the error will be thrown by rollup rather than Babel.